### PR TITLE
Set $STBT_CONFIG_FILE to an absolute path

### DIFF
--- a/stbt-docker
+++ b/stbt-docker
@@ -384,7 +384,7 @@ def main(argv):
          sed -i s/stb-tester:x:1000/stb-tester:x:{gid}/ /etc/group &&
          cd {cwd} &&
          sudo -u stb-tester -E -- \\
-             env STBT_CONFIG_FILE={config_filename} \\
+             env STBT_CONFIG_FILE=/var/lib/stbt/test-pack/{config_filename} \\
                  PYTHONPATH=$PYTHONPATH:/usr/lib/stbt \\
              "$0" "$@" """).format(
          uid=inner_uid, gid=inner_gid, cwd=pipes.quote(innerdir),

--- a/tests/test-stbt-docker.sh
+++ b/tests/test-stbt-docker.sh
@@ -118,3 +118,10 @@ test_that_stbt_docker_respects_pythonpath() {
 	    "Fake stbt to test stbt-docker's PYTHONPATH handling."
 	EOF
 }
+
+test_that_stbt_config_file_is_absolute_path() {
+    load_test_pack empty-test-pack
+    "$srcdir"/stbt-docker bash -c \
+        'cd config && stbt config test_pack.stbt_version | tee ../output'
+    [ "$(cat output)" = "0.21" ] || fail "Didn't find \$STBT_CONFIG_FILE"
+}


### PR DESCRIPTION
So that `stbt` will find it no matter which directory you run `stbt`
from.
