### PR TITLE
Fix `stbt.ocr` when running stbt-docker with uid != 1000

### DIFF
--- a/stbt-docker
+++ b/stbt-docker
@@ -382,10 +382,14 @@ def main(argv):
               -o -print0 | xargs -0 chown -f {uid}:{gid} &&
          sed -i s/stb-tester:x:1000:1000/stb-tester:x:{uid}:{gid}/ /etc/passwd &&
          sed -i s/stb-tester:x:1000/stb-tester:x:{gid}/ /etc/group &&
+         mkdir -p /run/user/{uid} &&
+         chown -R {uid}:{gid} /run/user/{uid} &&
+         chmod 0700 /run/user/{uid} &&
          cd {cwd} &&
          sudo -u stb-tester -E -- \\
              env STBT_CONFIG_FILE={config_filename} \\
                  PYTHONPATH=$PYTHONPATH:/usr/lib/stbt \\
+                 XDG_RUNTIME_DIR=/run/user/{uid} \\
              "$0" "$@" """).format(
          uid=inner_uid, gid=inner_gid, cwd=pipes.quote(innerdir),
          config_filename=pipes.quote(config_filename))]

--- a/tests/test-stbt-docker.sh
+++ b/tests/test-stbt-docker.sh
@@ -82,8 +82,9 @@ test_that_with_different_uid_we_still_have_permissions_to_files() {
     sudo chmod 700 ~test-user || fail "Test setup failed"
 
     sudo -u test-user bash <<-'EOF'
-		stbt-docker bash -c 'touch hello'
-		[ "$(ls -l hello | awk '{ print $3 }')" == 'test-user' ]
+		stbt-docker bash -c 'touch hello' &&
+		[ "$(ls -l hello | awk '{ print $3 }')" == 'test-user' ] &&
+		stbt-docker sh -c 'touch $XDG_RUNTIME_DIR/test'
 		EOF
     [ "$?" == 0 ] || fail "UID switching broken"
 }


### PR DESCRIPTION
`stbt.ocr` works by writing files into `$XDG_RUNTIME_DIR` allowing them to be passed to tesseract for processing.  The test-pack entrypoint sets this to `/run/users/1000` which has owner 1000 (stb-tester).  This is correct if your UID is 1000, but incorrect otherwise.  This causes `stbt.ocr` to fail with:

```
OSError: [Errno 13] Permission denied: '/run/user/1000/stbt-ocr-.......'
```

This commit fixes this issue by creating `/run/users/{uid}` instead with the owner matching the user that stbt-docker is running as and setting `$XDG_RUNTIME_DIR` appropriately.
