### PR TITLE
container_to_host_path.py: Fix inspecting non-host volumes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ install:
 
 script:
  - make check
+ - docker run -it -v /var/run/docker.sock:/var/run/docker.sock:ro
+     -v $PWD:/src:rw --workdir=/src stbtester/stbt-docker-selftest
+     tests/run-tests.sh tests/test-stbt-docker.sh

--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,9 @@ check-integrationtests :
 check-pylint:
 	./pylint.sh stbt-docker
 
+publish-test-docker-container:
+	docker build -t stbtester/stbt-docker-selftest tests/
+	docker push stbtester/stbt-docker-selftest
+
 .PHONY: all clean check check-integrationtests check-pylint
 .PHONY: FORCE

--- a/stbt-docker
+++ b/stbt-docker
@@ -121,6 +121,13 @@ def native_to_unix_path(path):
         return path
 
 
+def list_mounts(container):
+    for x in container.get('Mounts', []):
+        yield x
+    for k, v in container.get('Volumes', {}).items():
+        yield {'Destination': k, 'Source': v}
+
+
 def container_to_host_path(path):
     path = os.path.abspath(path)
     if not sys.platform.startswith('linux'):
@@ -165,11 +172,11 @@ def container_to_host_path(path):
         this_container = json.loads(subprocess.check_output(
             DOCKER + ['inspect', container]))[0]
         best_match = None
-        for cpath, hpath in this_container['Volumes'].items():
-            rel = os.path.relpath(path, cpath)
+        for mount in list_mounts(this_container):
+            rel = os.path.relpath(path, mount['Destination'])
             if '..' not in rel:
                 if best_match is None or len(rel) < len(best_match[1]):
-                    best_match = (hpath, rel)
+                    best_match = (mount['Source'], rel)
         if best_match:
             return os.path.join(*best_match)
         else:

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:16.04
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get -y install python docker.io

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -40,7 +40,7 @@ fail() { echo "error: $*"; exit 1; }
 skip() { echo "skipping: $*"; exit 77; }
 
 run() {
-    scratchdir=$(mktemp -d -t stb-tester.XXX)
+    scratchdir=$(mktemp -d -p "$testdir" -t stb-tester.XXX)
     [ -n "$scratchdir" ] || { echo "$0: mktemp failed" >&2; exit 1; }
     printf "$(bold $1...) "
     ( cd "$scratchdir" && $1 ) > "$scratchdir/log" 2>&1

--- a/tests/test-stbt-docker.sh
+++ b/tests/test-stbt-docker.sh
@@ -1,12 +1,6 @@
 # Run with ./run-tests.sh
 
-skip_if_no_docker() {
-    which docker >/dev/null 2>&1 || skip "docker is not installed"
-    docker version >/dev/null 2>&1 || skip "docker does not work"
-}
-
 load_test_pack() {
-    skip_if_no_docker
     if [ -n "$2" ]; then
         outdir=$2
     else
@@ -19,8 +13,6 @@ load_test_pack() {
 }
 
 test_stbt_docker_fails_with_no_test_pack() {
-    skip_if_no_docker
-
     ! "$srcdir"/stbt-docker true || fail
 }
 


### PR DESCRIPTION
Docker lists its host volumes and normal volumes separately in the JSON.
This changed at some point post 1.6 when they introduced named volumes.