### PR TITLE
IDE support: Convert Windows absolute filename arguments

### DIFF
--- a/stbt-docker
+++ b/stbt-docker
@@ -328,6 +328,26 @@ def self_uid_gid():
         return 1000, 50
 
 
+def convert_windows_arguments(args, root):
+    """Identify arguments that look like absolute paths on a Windows system to
+    files in the test-pack and make them relative unix paths.
+
+    This is useful for IDE integrations where it's difficult to fix the tool to
+    provide paths relative to the test-pack root.
+    """
+    if sys.platform != "win32":
+        return args
+
+    out = []
+    for arg in args:
+        if os.path.isabs(arg):
+            rel = os.path.relpath(arg, root).replace("\\", "/")
+            if not rel.startswith('../'):
+                arg = "/var/lib/stbt/test-pack/" + os.path.relpath(arg, root)
+        out.append(arg)
+    return out
+
+
 def main(argv):
     parser = argparse.ArgumentParser(
         epilog=__doc__,
@@ -372,7 +392,7 @@ def main(argv):
             """))
         return 1
 
-    cmd = [args.command] + args.arguments
+    cmd = [args.command] + convert_windows_arguments(args.arguments, root)
 
     tty_arg = ['-t'] if sys.stdin.isatty() else []
 


### PR DESCRIPTION
...to unix-style absolute paths.

We don't touch paths outside the test-pack as we don't know how to map them
into the docker-container.  We don't touch relative paths inside the
test-pack because we don't have a reliable heuristic to identify them.

This is useful for IDE integration.  You can configure Eclipse to run
`stbt-docker stbt lint $filename` or
`stbt-docker stbt auto-selftest generate $filename`, but it won't make
`$filename` relative to the test-pack route.  We fix that by converting it
here.

I can think of one place where this heuristic will fail.  An argument
`--filename=c:\test-pack\tests\my_test.py` would not trigger rewriting.
I'm sure there are others too.

TODO:

- [ ] Decide that it's a good idea
- [ ] Investigate exactly which strings `os.path.isabs` considers an absolute path on Windows